### PR TITLE
Bump babel-eslint to 4.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "postcss": "^5.0.10"
   },
   "devDependencies": {
-    "babel-eslint": "4.1.3",
+    "babel-eslint": "4.1.8",
     "chai": "3.3.0",
     "del": "2.0.2",
     "gulp": "3.9.0",


### PR DESCRIPTION
It seems like because of babel/babel-eslint#243 running `npm run test` throws an error on `babel-eslint`. Bumping the dependency fixes it.